### PR TITLE
AGH#13044 & AGH#13517

### DIFF
--- a/includes/civicrm-directory-browse.php
+++ b/includes/civicrm-directory-browse.php
@@ -342,7 +342,7 @@ class CiviCRM_Directory_Browse {
 
 		// get listing markup
 		$markup .= $this->get_listing_markup( $results, $letter, $post_id );
-
+                $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
 		// add to data array
 		$data['listing'] = $markup;
 

--- a/includes/civicrm-directory-browse.php
+++ b/includes/civicrm-directory-browse.php
@@ -342,7 +342,7 @@ class CiviCRM_Directory_Browse {
 
 		// get listing markup
 		$markup .= $this->get_listing_markup( $results, $letter, $post_id );
-                $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
+		$markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
 		// add to data array
 		$data['listing'] = $markup;
 

--- a/includes/civicrm-directory-search.php
+++ b/includes/civicrm-directory-search.php
@@ -268,16 +268,12 @@ class CiviCRM_Directory_Search {
 		// init markup
 		$markup = '';
 
-		// init markup
-		if ( ! empty( $search ) ) {
+		// add heading
+		$markup = '<h3>' . __( 'Results', 'civicrm-directory' ) . '</h3>';
 
-			// add heading
-			$markup = '<h3>' . __( 'Results', 'civicrm-directory' ) . '</h3>';
-
-			// add listing
-			$markup .= $this->get_listing_markup( $results, $post_id );
-                        $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
-		}
+		// add listing
+		$markup .= $this->get_listing_markup( $results, $post_id );
+                $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
 
 		// add to data array
 		$data['listing'] = $markup;

--- a/includes/civicrm-directory-search.php
+++ b/includes/civicrm-directory-search.php
@@ -276,7 +276,7 @@ class CiviCRM_Directory_Search {
 
 			// add listing
 			$markup .= $this->get_listing_markup( $results, $post_id );
-
+                        $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
 		}
 
 		// add to data array

--- a/includes/civicrm-directory-search.php
+++ b/includes/civicrm-directory-search.php
@@ -273,7 +273,7 @@ class CiviCRM_Directory_Search {
 
 		// add listing
 		$markup .= $this->get_listing_markup( $results, $post_id );
-                $markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
+		$markup = apply_filters('civicrm_directory_ajax_markup', $markup, $results, $letter, $post_id);
 
 		// add to data array
 		$data['listing'] = $markup;


### PR DESCRIPTION
AGH#13044:
When searching for last name or browsing by letter with AJAX working, the directory results lose the stylings applied via filter 'civicrm_directory_listing_markup'.

Added filter 'civicrm_directory_ajax_markup' so we have the ability to modify the markup returned via AJAX as well as by URL with the same functions we used with 'civicrm_directory_listing_markup'.

AGH#13517:
An empty search or a browse of 'ALL' returned zero results. The browse 'ALL' was a typo in our nasi-directory plugin but the empty search was found to return zero results by design, which seemed un-intuitive.